### PR TITLE
Convert to a pure ESM package

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <title>UIEvent Simulator</title>
+  <script type="importmap">
+    {
+      "imports": {
+        "ui-event-simulator": "/ui-event-simulator.js"
+      }
+    }
+  </script>
 </head>
 <body>
   <div id="test" style="width: 400px; height: 400px; background: red;" tabindex="1"></div>
+  <script type="module">
+    import UIEventSimulator from 'ui-event-simulator';
 
-  <script src="ui-event-simulator.js"></script>
-  <script>
     document.body.addEventListener('click',(e)=>alert(e.type+" Body"));
 
     var test = document.getElementById('test');

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
+  "type": "module",
   "name": "ui-event-simulator",
   "version": "1.0.0",
   "description": "Simulate browser UI-Events",
-  "main": "ui-event-simulator.js",
+  "exports": "./ui-event-simulator.js",
+  "engines": {
+    "node": ">=16"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/Falke-Design/ui-event-simulator.git"

--- a/ui-event-simulator.js
+++ b/ui-event-simulator.js
@@ -281,5 +281,4 @@ const UIEventSimulator = {
   }
 };
 
-if (typeof window !== 'undefined') window.UIEventSimulator = UIEventSimulator;
-if (typeof module !== 'undefined') module.exports = UIEventSimulator;
+export default UIEventSimulator;


### PR DESCRIPTION
Converts to a [pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c). This is needed for modern tooling that no longer supports CommonJS such as [Web Test Runner](https://modern-web.dev/docs/test-runner/overview/), which we intend to use for Leaflet.

This removes the CommonJS export and window global as a manner of using the package, making this a breaking change.